### PR TITLE
Feature/dockerize server

### DIFF
--- a/daaukins/server/Dockerfile
+++ b/daaukins/server/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.20.2-alpine3.17 as deps
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+FROM deps as builder
+
+WORKDIR /app
+
+RUN go build -o main .
+
+FROM alpine:3.17
+
+WORKDIR /app
+
+COPY --from=builder /app/main .
+
+# Command expects that the config file is mounted to /app/server.yaml
+CMD ["/app/main"]

--- a/daaukins/server/bin/setup.sh
+++ b/daaukins/server/bin/setup.sh
@@ -2,3 +2,5 @@
 
 docker pull networkboot/dhcpd:1.2.0
 docker pull coredns/coredns:1.10.0
+docker pull andreaswachs/daaukins-server:latest
+docker pull andreaswachs/placeholder_vuln_server:latest

--- a/daaukins/server/docker-compose.yaml
+++ b/daaukins/server/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.9'
+
+services:
+  example:
+    image: andreaswachs/daaukins-server:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - 50051
+    ports:
+      - 50051:50051
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./server.yaml:/app/server.yaml:ro
+      - ./store.yaml:/app/store.yaml:ro
+      - /tmp:/tmp

--- a/daaukins/server/server.yaml
+++ b/daaukins/server/server.yaml
@@ -1,6 +1,6 @@
 server_mode: leader
 service_port: 50051
-followers:
-  - name: FirstFollower
-    address: 0.0.0.0
-    port: 50052 
+followers: []
+  #   - name: FirstFollower
+  #     address: 0.0.0.0
+  #     port: 50052 


### PR DESCRIPTION
# Changes

- Dockerized the server, such that it can operate from within a docker container itself.

This enables easier deployments of the server, where a fresh server currently only needs to have docker and docker-compose installed, along with transfering the `server.yaml` and `store.yaml` file