### PR TITLE
Bug/removing labs

### DIFF
--- a/daaukins/server/challenge/challenge.go
+++ b/daaukins/server/challenge/challenge.go
@@ -12,6 +12,7 @@ type ProvisionChallengeOptions struct {
 	Image       string
 	DNSServers  []string
 	DNSSettings []string
+	LabID       string
 }
 
 type Challenge struct {
@@ -30,11 +31,12 @@ func Provision(conf *ProvisionChallengeOptions) (*Challenge, error) {
 	}
 
 	containerConfiguration := &docker.CreateContainerOptions{
-		Name: fmt.Sprintf("daaukins-%s", uuid.New().String()),
+		Name: fmt.Sprintf("daaukins-challenge-%s", uuid.New().String()),
 		Config: &docker.Config{
 			Image: conf.Image,
 			Labels: map[string]string{
-				"daaukins": "true",
+				"daaukins":     "challenge",
+				"daaukins.lab": conf.LabID,
 			},
 		},
 		HostConfig: &docker.HostConfig{

--- a/daaukins/server/frontend/frontend.go
+++ b/daaukins/server/frontend/frontend.go
@@ -33,6 +33,7 @@ type ProvisionFrontendOptions struct {
 	DNS       []string
 	Ip        string
 	ProxyPort int
+	LabID     string
 }
 
 func Provision(options *ProvisionFrontendOptions) (*frontend, error) {
@@ -45,7 +46,8 @@ func Provision(options *ProvisionFrontendOptions) (*frontend, error) {
 		Config: &docker.Config{
 			Image: config.GetDockerConfig().Frontend.Image,
 			Labels: map[string]string{
-				"daaukins": "true",
+				"daaukins":     "frontend",
+				"daaukins.lab": options.LabID,
 			},
 			Memory: 2 * 1024 * 1024 * 1024, // 2 GB
 			Tty:    true,

--- a/daaukins/server/labs/dhcp/dhcp.go
+++ b/daaukins/server/labs/dhcp/dhcp.go
@@ -21,6 +21,7 @@ type ProvisionDHCPOptions struct {
 	DNSAddr     string
 	Subnet      string
 	NetworkMode string
+	LabID       string
 }
 
 func format(subnet string, lastOctet int) string {
@@ -62,8 +63,9 @@ func Provision(options *ProvisionDHCPOptions) (*DHCPService, error) {
 			Image:  config.GetDockerConfig().Dhcp.Image,
 			Memory: 128 * 1024 * 1024,
 			Labels: map[string]string{
-				"daaukins":         "true",
-				"daaukins-service": "dhcp",
+				"daaukins":         "network-service",
+				"daaukins.service": "dhcp",
+				"daaukins.lab":     options.LabID,
 			},
 			Cmd: []string{
 				"eth0",

--- a/daaukins/server/labs/dns/dns.go
+++ b/daaukins/server/labs/dns/dns.go
@@ -40,6 +40,7 @@ type ZoneFileEntry struct {
 
 type ProvisionDNSOptions struct {
 	ZoneFileEntries []ZoneFileEntry
+	LabID           string
 }
 
 func Provision(options *ProvisionDNSOptions) (*DNSService, error) {
@@ -84,8 +85,9 @@ func Provision(options *ProvisionDNSOptions) (*DNSService, error) {
 			Image:  config.GetDockerConfig().Dns.Image,
 			Memory: 128 * 1024 * 1024,
 			Labels: map[string]string{
-				"daaukins":         "true",
-				"daaukins-service": "dns",
+				"daaukins":         "network-service",
+				"daaukins.service": "dns",
+				"daaukins.lab":     options.LabID,
 			},
 		},
 		HostConfig: &docker.HostConfig{

--- a/daaukins/server/networks/networks.go
+++ b/daaukins/server/networks/networks.go
@@ -21,10 +21,12 @@ type Network struct {
 	network *docker.Network
 	subnet  string
 	name    string
+	labID   string
 }
 
 type ProvisionNetworkOptions struct {
 	Subnet string
+	LabID  string
 }
 
 func Provision(conf ProvisionNetworkOptions) (*Network, error) {
@@ -36,6 +38,7 @@ func Provision(conf ProvisionNetworkOptions) (*Network, error) {
 	return &Network{
 		subnet: subnet,
 		name:   utils.RandomName(),
+		labID:  conf.LabID,
 	}, nil
 }
 
@@ -90,7 +93,8 @@ func (n *Network) Create() error {
 				Subnet: n.subnet,
 			}}},
 		Labels: map[string]string{
-			"daaukins": "network",
+			"daaukins":     "network",
+			"daaukins.lab": n.labID,
 		},
 	})
 

--- a/daaukins/server/service/service.go
+++ b/daaukins/server/service/service.go
@@ -389,7 +389,7 @@ func (s *Server) RemoveLab(context context.Context, request *RemoveLabRequest) (
 		responseLock := sync.Mutex{}
 
 		// Check if the lab is hosted on this server
-		lab, err := labs.GetByName(request.Id)
+		lab, err := labs.GetById(request.Id)
 		if err == nil {
 			if lab != nil {
 				err = lab.Remove()


### PR DESCRIPTION
# Changes

- Configures challenges, dns, dhcp, frontend and proxy with proper labels, such that we can find them via the lab ID. Makes for a more stable lab removal process
- Removes containers using multithreading, such that removal of a lab happens before the 10 sec request timeout (from the `dkn` tool)

Fixes #66
Fixes #65 