### PR TITLE
Feature/connection retires

### DIFF
--- a/daaukins/server/go.mod
+++ b/daaukins/server/go.mod
@@ -3,7 +3,7 @@ module github.com/andreaswachs/bachelors-project/daaukins/server
 go 1.20
 
 require (
-	github.com/andreaswachs/daaukins-service v0.2.1
+	github.com/andreaswachs/daaukins-service v0.2.2
 	github.com/andreaswachs/sizes v0.3.0
 	github.com/fsouza/go-dockerclient v1.9.7
 	github.com/google/uuid v1.3.0

--- a/daaukins/server/go.sum
+++ b/daaukins/server/go.sum
@@ -16,6 +16,8 @@ github.com/andreaswachs/daaukins-service v0.2.0 h1:rB+3UoQATYT3INEXnia+OEVOBjCgo
 github.com/andreaswachs/daaukins-service v0.2.0/go.mod h1:/pQLycFO2XFcQQ18uEKECfPr9SN4K8FtKsJp111NWgY=
 github.com/andreaswachs/daaukins-service v0.2.1 h1:5wk/ql8h9TPfzSIaYZADP1FkWTWyaD/9KUbLa4Tug4I=
 github.com/andreaswachs/daaukins-service v0.2.1/go.mod h1:/pQLycFO2XFcQQ18uEKECfPr9SN4K8FtKsJp111NWgY=
+github.com/andreaswachs/daaukins-service v0.2.2 h1:Ydo6wQJtugRbxeUCCnfl4Q4cBO2e8HPLqLOBJheBp8g=
+github.com/andreaswachs/daaukins-service v0.2.2/go.mod h1:/pQLycFO2XFcQQ18uEKECfPr9SN4K8FtKsJp111NWgY=
 github.com/andreaswachs/sizes v0.3.0 h1:yJYHokX4bU0a7EzB9Q9jfcmuF+Zf0WCgoW+dxxU4vwU=
 github.com/andreaswachs/sizes v0.3.0/go.mod h1:zbJx4l9RYiGg4DRkcPj685G0NpfedGF9ZyrgqV8uo0M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=

--- a/daaukins/server/service/connections.go
+++ b/daaukins/server/service/connections.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"sync"
+	"time"
 
 	"github.com/andreaswachs/bachelors-project/daaukins/server/config"
 	service "github.com/andreaswachs/daaukins-service"
@@ -11,69 +11,98 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
+type connectionStatus uint8
+
+const (
+	connected connectionStatus = iota
+	disconnected
+)
+
+type connAttempt struct {
+	follower *follower
+	result   connectionStatus
+}
+
 // ConnectFollowers attepmts to connect to all follower in the config
 func ConnectFollowers() ([]*follower, []*follower) {
 	connectedFollowerBuffer := make([]*follower, 0)
 	disconnectedFollowerBuffer := make([]*follower, 0)
 
-	connectedFollowerBufferLock := sync.Mutex{}
-	disconnectedFollowerBufferLock := sync.Mutex{}
-	wg := sync.WaitGroup{}
+	attemps := make(chan connAttempt)
 
-	for _, followerConfig := range config.GetFollowers() {
+	for _, follower := range disconnectedFollowers {
 		log.Debug().
-			Str("address", followerConfig.Address).
-			Int("port", followerConfig.Port).
+			Str("address", follower.config.Address).
+			Int("port", follower.config.Port).
 			Msg("Attempting to connect to follower")
 
-		wg.Add(1)
-		go func(f config.FollowerConfig) {
-			defer wg.Done()
-			followerBuffer := &follower{
-				config: f,
-			}
-
-			log.Debug().
-				Str("address", followerBuffer.config.Address).
-				Int("port", followerBuffer.config.Port).
-				Msg("Begin attempt to connect to follower")
-
-			// TODO: mTLS
-			conn, err := grpc.Dial(fmt.Sprintf("%s:%d", f.Address, f.Port), grpc.WithInsecure())
-			if err != nil {
-				disconnectedFollowerBufferLock.Lock()
-				defer disconnectedFollowerBufferLock.Unlock()
-
-				disconnectedFollowerBuffer = append(disconnectedFollowerBuffer, followerBuffer)
-				log.Error().Err(err).Msgf("Failed to connect to follower %s:%d", f.Address, f.Port)
-				return
-			}
-
-			serviceClient := service.NewServiceClient(conn)
-			followerBuffer.client = serviceClient
-
-			response, err := serviceClient.GetServerMode(context.Background(), &service.GetServerModeRequest{})
-			if err != nil {
-				log.Error().Err(err).Msgf("Failed to get server mode from follower %s:%d", f.Address, f.Port)
-				return
-			}
-
-			if response.Mode == config.ModeLeader.String() {
-				log.Error().Msgf("Server %s:%d is a leader, but it should be a follower. The server will not be used.", f.Address, f.Port)
-				return
-			}
-
-			followerBuffer.serverId = response.ServerId
-
-			connectedFollowerBufferLock.Lock()
-			defer connectedFollowerBufferLock.Unlock()
-
-			connectedFollowerBuffer = append(connectedFollowerBuffer, followerBuffer)
-			log.Info().Msgf("Connected to follower %s:%d", f.Address, f.Port)
-		}(followerConfig)
+		go connect(follower, attemps)
 	}
 
-	wg.Wait()
+	for i := 0; i < len(disconnectedFollowers); i++ {
+		attempt := <-attemps
+		switch attempt.result {
+		case connected:
+			connectedFollowerBuffer = append(connectedFollowerBuffer, attempt.follower)
+		case disconnected:
+			disconnectedFollowerBuffer = append(disconnectedFollowerBuffer, attempt.follower)
+		}
+	}
 
 	return connectedFollowerBuffer, disconnectedFollowerBuffer
+}
+
+func connect(f *follower, comm chan<- connAttempt) {
+	log.Debug().
+		Str("address", f.config.Address).
+		Int("port", f.config.Port).
+		Msg("Begin attempt to connect to follower")
+
+	ctx, cancel := shortTimeoutContext()
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, fmt.Sprintf("%s:%d", f.config.Address, f.config.Port), grpc.WithInsecure())
+	if err != nil {
+		comm <- connAttempt{
+			follower: f,
+			result:   disconnected,
+		}
+
+		log.Error().Err(err).Msgf("Failed to connect to follower %s:%d", f.config.Address, f.config.Port)
+		return
+	}
+
+	serviceClient := service.NewServiceClient(conn)
+	f.client = serviceClient
+
+	response, err := serviceClient.GetServerMode(context.Background(), &service.GetServerModeRequest{})
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to get server mode from follower %s:%d", f.config.Address, f.config.Port)
+		comm <- connAttempt{
+			follower: f,
+			result:   disconnected,
+		}
+		return
+	}
+
+	if response.Mode == config.ModeLeader.String() {
+		log.Error().Msgf("Server %s:%d is a leader, but it should be a follower. The server will not be used.", f.config.Address, f.config.Port)
+		comm <- connAttempt{
+			follower: f,
+			result:   disconnected,
+		}
+		return
+	}
+
+	f.serverId = response.ServerId
+
+	log.Info().Msgf("Connected to follower %s:%d", f.config.Address, f.config.Port)
+	comm <- connAttempt{
+		follower: f,
+		result:   connected,
+	}
+}
+
+func shortTimeoutContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 3*time.Second)
 }

--- a/daaukins/server/service/service.go
+++ b/daaukins/server/service/service.go
@@ -119,11 +119,11 @@ func probeConnectedFollowers() {
 					out <- i
 				}
 
-				cancel()
 			}(i, f, followersToMove)
 		}
 
 		sleepContext(ctx, 3*time.Second)
+		cancel()
 
 		// Move all followers that failed to respond to the disconnected list
 		for len(followersToMove) > 0 {

--- a/daaukins/server/service/service.go
+++ b/daaukins/server/service/service.go
@@ -77,7 +77,8 @@ func Initialize() {
 		})
 	}
 
-	go updateFollowers()
+	go updateFollowers()         // Attempts to connect all disconnected followers
+	go probeConnectedFollowers() // Attempts to check if any connected followers have disconnected
 }
 
 func getConnectedFollowers() []*follower {
@@ -94,6 +95,48 @@ func getDisconnectedFollowers() []*follower {
 	return disconnectedFollowers
 }
 
+// https://stackoverflow.com/a/62287775
+func sleepContext(ctx context.Context, delay time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(delay):
+	}
+}
+
+func probeConnectedFollowers() {
+	for {
+		followersLock.Lock()
+		followersToMove := make(chan int)
+		ctx, cancel := shortTimeoutContext()
+
+		for i, f := range connectedFollowers {
+			go func(i int, f *follower, out chan<- int) {
+
+				// Ping, and only then move the follower to the disconnected list if it fails
+				_, err := f.client.Ping(ctx, &emptypb.Empty{})
+				if err != nil {
+					log.Warn().Err(err).Msgf("failed to ping follower %s", f.config.Name)
+					out <- i
+				}
+
+				cancel()
+			}(i, f, followersToMove)
+		}
+
+		sleepContext(ctx, 3*time.Second)
+
+		// Move all followers that failed to respond to the disconnected list
+		for len(followersToMove) > 0 {
+			i := <-followersToMove
+			disconnectedFollowers = append(disconnectedFollowers, connectedFollowers[i])
+			connectedFollowers = append(connectedFollowers[:i], connectedFollowers[i+1:]...)
+		}
+
+		followersLock.Unlock()
+		time.Sleep(5 * time.Second)
+	}
+}
+
 func updateFollowers() {
 	for {
 		followersLock.Lock()
@@ -108,7 +151,7 @@ func Stop() {
 	server.GracefulStop()
 }
 
-func (s *Server) HaveCapacity(context context.Context, request *service.HaveCapacityRequest) (*service.HaveCapacityResponse, error) {
+func (s *Server) HaveCapacity(ctx context.Context, request *service.HaveCapacityRequest) (*service.HaveCapacityResponse, error) {
 	if config.GetServerMode() == config.ModeLeader {
 		// If we're the leader, then we will query all follower and return true if a single follower has capacity
 
@@ -145,7 +188,10 @@ func (s *Server) HaveCapacity(context context.Context, request *service.HaveCapa
 			go func(m *follower) {
 				defer wg.Done()
 
-				response, err := m.client.HaveCapacity(context, request)
+				shortCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+
+				response, err := m.client.HaveCapacity(shortCtx, request)
 				if err != nil {
 					log.Error().Err(err).Msg("failed to ask follower for capacity")
 					return
@@ -197,9 +243,9 @@ func (s *Server) HaveCapacity(context context.Context, request *service.HaveCapa
 
 	// If we're a follower, then we will check if we have capacity and return that
 	log.Debug().Msg("Checking if we have capacity")
-	return HaveCapacity(context, request)
+	return HaveCapacity(ctx, request)
 }
-func (s *Server) ScheduleLab(context context.Context, request *service.ScheduleLabRequest) (*service.ScheduleLabResponse, error) {
+func (s *Server) ScheduleLab(ctx context.Context, request *service.ScheduleLabRequest) (*service.ScheduleLabResponse, error) {
 	if config.GetServerMode() == config.ModeLeader {
 		// Ask all follower what their capacity is and compare them including our own capacity.
 		// Schedule the lab on the follower with the most capacity (this instance included)
@@ -239,7 +285,10 @@ func (s *Server) ScheduleLab(context context.Context, request *service.ScheduleL
 			wg.Add(1)
 			go func(m *follower) {
 				defer wg.Done()
-				response, err := m.client.HaveCapacity(context, &service.HaveCapacityRequest{
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := m.client.HaveCapacity(shortCtx, &service.HaveCapacityRequest{
 					Lab: request.Lab,
 				})
 				if err != nil {
@@ -286,17 +335,17 @@ func (s *Server) ScheduleLab(context context.Context, request *service.ScheduleL
 
 		if bestFollower.isSelf {
 			log.Info().Msg("Scheduling lab on leader")
-			return ScheduleLab(context, request)
+			return ScheduleLab(ctx, request)
 		}
 
 		log.Info().Msgf("Scheduling lab on follower %s:%d", bestFollower.follower.config.Address, bestFollower.follower.config.Port)
-		return bestFollower.follower.client.ScheduleLab(context, request)
+		return bestFollower.follower.client.ScheduleLab(ctx, request)
 	}
 
 	// In this case, this server instance is a folloer and we'll just schedule the lab on ourself
-	return ScheduleLab(context, request)
+	return ScheduleLab(ctx, request)
 }
-func (s *Server) GetLab(context context.Context, request *service.GetLabRequest) (*service.GetLabResponse, error) {
+func (s *Server) GetLab(ctx context.Context, request *service.GetLabRequest) (*service.GetLabResponse, error) {
 	if config.GetServerMode() == config.ModeLeader {
 		wg := sync.WaitGroup{}
 		responses := make([]*askGetLabResponse, 0)
@@ -321,7 +370,10 @@ func (s *Server) GetLab(context context.Context, request *service.GetLabRequest)
 			wg.Add(1)
 			go func(m *follower) {
 				defer wg.Done()
-				response, err := m.client.GetLab(context, &service.GetLabRequest{
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := m.client.GetLab(shortCtx, &service.GetLabRequest{
 					Id: request.Id,
 				})
 				if err != nil {
@@ -367,16 +419,16 @@ func (s *Server) GetLab(context context.Context, request *service.GetLabRequest)
 		return theFollower.response, nil
 	}
 
-	return GetLab(context, request)
+	return GetLab(ctx, request)
 }
-func (s *Server) GetLabs(context context.Context, request *service.GetLabsRequest) (*service.GetLabsResponse, error) {
+func (s *Server) GetLabs(ctx context.Context, request *service.GetLabsRequest) (*service.GetLabsResponse, error) {
 	if config.GetServerMode() == config.ModeLeader {
 		wg := sync.WaitGroup{}
 		responses := make([]*service.GetLabsResponse, 0)
 		responseLock := sync.Mutex{}
 
 		// Get labs from ourselves
-		localLabs, err := GetLabs(context, request)
+		localLabs, err := GetLabs(ctx, request)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to get labs from self")
 		}
@@ -391,7 +443,10 @@ func (s *Server) GetLabs(context context.Context, request *service.GetLabsReques
 			wg.Add(1)
 			go func(m *follower) {
 				defer wg.Done()
-				response, err := m.client.GetLabs(context, &service.GetLabsRequest{})
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := m.client.GetLabs(shortCtx, &service.GetLabsRequest{})
 				if err != nil {
 					log.Error().Err(err).Msgf("Failed to get labs from follower %s:%d", m.config.Address, m.config.Port)
 				}
@@ -427,10 +482,10 @@ func (s *Server) GetLabs(context context.Context, request *service.GetLabsReques
 		return response, nil
 	}
 
-	return GetLabs(context, request)
+	return GetLabs(ctx, request)
 }
 
-func (s *Server) RemoveLab(context context.Context, request *service.RemoveLabRequest) (*service.RemoveLabResponse, error) {
+func (s *Server) RemoveLab(ctx context.Context, request *service.RemoveLabRequest) (*service.RemoveLabResponse, error) {
 	if config.GetServerMode() == config.ModeLeader {
 		// Ask all follower for the given lab
 		// If we find it, remove it
@@ -459,7 +514,10 @@ func (s *Server) RemoveLab(context context.Context, request *service.RemoveLabRe
 			wg.Add(1)
 			go func(m *follower) {
 				defer wg.Done()
-				response, err := m.client.GetLab(context, &service.GetLabRequest{
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := m.client.GetLab(shortCtx, &service.GetLabRequest{
 					Id: request.Id,
 				})
 				if err != nil {
@@ -493,7 +551,7 @@ func (s *Server) RemoveLab(context context.Context, request *service.RemoveLabRe
 		}
 
 		// Remove the lab from the follower
-		_, err = theFollower.client.RemoveLab(context, &service.RemoveLabRequest{
+		_, err = theFollower.client.RemoveLab(ctx, &service.RemoveLabRequest{
 			Id: request.Id,
 		})
 		if err != nil {
@@ -504,7 +562,7 @@ func (s *Server) RemoveLab(context context.Context, request *service.RemoveLabRe
 		return &service.RemoveLabResponse{Ok: true}, nil
 	}
 
-	return RemoveLab(context, request)
+	return RemoveLab(ctx, request)
 }
 
 func (s *Server) RemoveLabs(ctx context.Context, request *service.RemoveLabsRequest) (*service.RemoveLabsResponse, error) {
@@ -607,15 +665,23 @@ func (s *Server) GetServers(ctx context.Context, _ *emptypb.Empty) (*service.Get
 			defer numLabsWg.Done()
 			log.Debug().Msgf("GetServers(): Getting number of labs from follower %s:%d", f.config.Address, f.config.Port)
 
-			response, err := f.client.GetLabs(context.Background(), &service.GetLabsRequest{})
-			if err != nil {
-				log.Error().Err(err).Msgf("Failed to get number of labs from follower %s:%d", f.config.Address, f.config.Port)
-				return
-			}
-
 			var numLabs int32
-			if response != nil && response.GetLabs() != nil {
-				numLabs = int32(len(response.GetLabs()))
+
+			if isConnected {
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := f.client.GetLabs(shortCtx, &service.GetLabsRequest{})
+				if err != nil {
+					// The server is offline
+					log.Error().Err(err).Msgf("Failed to get number of labs from follower %s:%d", f.config.Address, f.config.Port)
+					isConnected = false
+				}
+
+				if response != nil && response.GetLabs() != nil {
+					numLabs = int32(len(response.GetLabs()))
+				}
+
 			}
 
 			serversSliceLock.Lock()
@@ -677,7 +743,11 @@ func (s *Server) GetFrontends(ctx context.Context, request *service.GetFrontends
 			wg.Add(1)
 			go func(f *follower) {
 				defer wg.Done()
-				response, err := f.client.GetFrontends(ctx, &service.GetFrontendsRequest{})
+
+				shortCtx, cancel := shortTimeoutContext()
+				defer cancel()
+
+				response, err := f.client.GetFrontends(shortCtx, &service.GetFrontendsRequest{})
 				if err != nil {
 					log.Error().
 						Err(err).

--- a/daaukins/server/service/service.go
+++ b/daaukins/server/service/service.go
@@ -21,7 +21,7 @@ import (
 var (
 	connectedFollowers    []*follower
 	disconnectedFollowers []*follower
-	followersLock         *sync.Mutex
+	followersLock         = &sync.Mutex{}
 
 	server *grpc.Server
 	port   int

--- a/daaukins/server/service/service.go
+++ b/daaukins/server/service/service.go
@@ -773,3 +773,7 @@ func (s *Server) GetFrontends(ctx context.Context, request *service.GetFrontends
 
 	return GetFrontends(ctx, request)
 }
+
+func (s *Server) Ping(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}


### PR DESCRIPTION
# Changes

Allows for the leader server to retry connecting to disconnected servers.

Connected followers are probed intermittently for connectivity. Should they not be reachable, they are marked as disconnected.

Disconnected followers are attempted to get connected to intermittently. Should a connected be established, the follower is marked as connected to.

All this happens intermittently. The server does not do anything if any rpc fails due to connectivity issues at the moment.