### PR TITLE
Use longer lived contexts for scheduling/removnig

### DIFF
--- a/daaukins/client/api/connection.go
+++ b/daaukins/client/api/connection.go
@@ -34,8 +34,12 @@ func Initialize(address, port string) error {
 	return nil
 }
 
-func newCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 10*time.Second)
+func shortLivedCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
+func longLivedCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 60*time.Second)
 }
 
 func getClient() service.ServiceClient {
@@ -49,7 +53,7 @@ func getClient() service.ServiceClient {
 }
 
 func connect(address, ip string) (*grpc.ClientConn, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := shortLivedCtx()
 	defer cancelFunc()
 
 	return grpc.DialContext(ctx, fmt.Sprintf("%s:%s", address, ip),

--- a/daaukins/client/api/get.go
+++ b/daaukins/client/api/get.go
@@ -8,28 +8,28 @@ import (
 
 func GetLabs(serverId string) (*service.GetLabsResponse, error) {
 	// if id is "", then all getting all labs is implied
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := shortLivedCtx()
 	defer cancelFunc()
 
 	return getClient().GetLabs(ctx, &service.GetLabsRequest{})
 }
 
 func GetLab(id string) (*service.GetLabResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := shortLivedCtx()
 	defer cancelFunc()
 
 	return getClient().GetLab(ctx, &service.GetLabRequest{Id: id})
 }
 
 func GetServers() (*service.GetServersResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := shortLivedCtx()
 	defer cancelFunc()
 
 	return getClient().GetServers(ctx, &emptypb.Empty{})
 }
 
 func GetFrontends() (*service.GetFrontendsResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := shortLivedCtx()
 	defer cancelFunc()
 
 	response, err := getClient().GetFrontends(ctx, &service.GetFrontendsRequest{})

--- a/daaukins/client/api/remove.go
+++ b/daaukins/client/api/remove.go
@@ -3,14 +3,14 @@ package api
 import service "github.com/andreaswachs/daaukins-service"
 
 func RemoveLab(id string) (*service.RemoveLabResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := longLivedCtx()
 	defer cancelFunc()
 
 	return getClient().RemoveLab(ctx, &service.RemoveLabRequest{Id: id})
 }
 
 func RemoveLabs(serverId string) (*service.RemoveLabsResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := longLivedCtx()
 	defer cancelFunc()
 
 	return getClient().RemoveLabs(ctx, &service.RemoveLabsRequest{ServerId: serverId})

--- a/daaukins/client/api/schedule.go
+++ b/daaukins/client/api/schedule.go
@@ -3,7 +3,7 @@ package api
 import service "github.com/andreaswachs/daaukins-service"
 
 func ScheduleLab(lab, serverId string) (*service.ScheduleLabResponse, error) {
-	ctx, cancelFunc := newCtx()
+	ctx, cancelFunc := longLivedCtx()
 	defer cancelFunc()
 
 	return getClient().ScheduleLab(ctx, &service.ScheduleLabRequest{Lab: lab, ServerId: serverId})


### PR DESCRIPTION
# Changes

Fixes timeouts when putting heavy load in the server(s) by using significantly longer timeouts in contexts for scheduling and removing RPC's.

Fixes #62 